### PR TITLE
Get started on official project documentation in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,25 @@ Lobbster is an open-source project to help lobbyists comply with reporting requi
 Section 2-243 of the _Code of the City of Coral Gables_ creates requirements for non-exempt lobbyists to submit five types of documentation, four of which are submitted as forms to the City Clerk.
 
 * *Annual Registration Application*
-  * Each year, a separate copy of this application must be submitted for each principal that the lobbyist represents.
-  * A $250 annual fee is collected with the application if 1) the lobbyist hasn't already paid the fee for the year that the application applies to and 2) the registration application doesn't qualify for any fee exemptions.
+  * This application is principal-specific; each year, the lobbyist must submit a separate copy of the application for each principal that they represent.
+  * A $250 annual fee is collected with the application unless the lobbyist has already paid the fee for the year or the application qualifies for a fee exemption.
 * *Issue Application*
-  * Each year, for each principal that the lobbyist represents, a copy of this application must be submitted submitted to list all of the issues that the lobbyist is representing for that principal.
+  * This application is also principal-specific; each year, the lobbyist must submit a separate copy of the application for each of their principals, to list all of the issues that they represent for that principal.
   * Because this application is principal-specific, duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
 * *Lobbyist Expenditure Report*
-  * On October 1st of each year, lobbyists who were registered for the prior year must submit expenditure reports for the prior year, regardless of whether or not any expenses were actually incurred.
   * These reports are specific to particular (principal, issue) pairs; a lobbyist must submit one report for each principle/issue combination that they represented.
+  * On October 1st of each year, lobbyists who were registered for the prior year must submit expenditure reports for the prior year, regardless of whether or not any expenses were actually incurred.
 * *Notice of Withdrawal of Lobbyist Registration*
   * Whenever a lobbyist withdraws as lobbyist for a principal, they must file a withdrawal notice.
 * *Amendments*
   * Amendments to these forms must be submitted whenever a change occurs to the information that has been filed. Whether the ammendments have a required format is unclear.
 
+Most of the forms require that the lobbyist sign a statement agreeing to some terms, or swearing under oath that the information on the form is correct.
+
 ### City Clerk Responsibilities
 * Approve lobbyist registration and issue applications.
+* Collect lobbyist fees---and presumably, return fees that are paid by mistake.
 * Maintain the records that are submitted.
-* Verify that fees are paid.
-* Presumably, return fees that are paid by mistake.
 * Prepare and publish reports on lobbying activity.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # Lobbster [![Build Status](https://travis-ci.org/Code-for-Miami/lobbster.svg?branch=setup_travis_ci)](https://travis-ci.org/Code-for-Miami/lobbster)
 
-## What
+Lobbster is an open-source project to help lobbyists comply with reporting requirements for the City of Coral Gables.
 
-Lobbster is an open-source website that helps lobbyists comply with reporting requirements for the City of Coral Gables.
+## Background
+### Lobbyist Responsibilities
+Ordinance No. 2017-44 creates requirements for lobbyists to submit four types of documents.
+
+* *Annual Registration Application*
+  * Each year, copy of this application must be submitted for each principal that the lobbyist represents.
+  * A $250 annual fee is collected with the application if 1) the lobbyist hasn't already paid the fee for the year that the application applies to and 2) the lobbyist application doesn't qualify for a number of exemptions.
+* *Issue Application*
+  * Each year, copies of this application must be submitted submitted to list all of the issues that the lobbyist is representing for its principles.
+  * A copy of this application is principle-specific, meaning that duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
+* *Lobbyist Expenditure Report*
+* *Notice of Withdrawal of Lobbyist Registration*
+
+In addition to these forms, the ordinace requires ammendements to be filed for ???.
+
+### City Clerk Responsibilities
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Lobbster is an open-source website that helps lobbyists comply with reporting re
 * Email capabilities to send reminders, receipts and  welcome messages to active Lobbyists.
 * Reporting capabilities (Report by Lobbyist, Principal , Issue, Year of Registration, etc.)
 
-#### Status
+## Status
 
 Gathering Requirements.
 
-#### Press
+## Press
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Ordinance No. 2017-44 creates requirements for lobbyists to submit four types of
   * Each year, copy of this application must be submitted for each principal that the lobbyist represents.
   * A $250 annual fee is collected with the application if 1) the lobbyist hasn't already paid the fee for the year that the application applies to and 2) the lobbyist application doesn't qualify for a number of exemptions.
 * *Issue Application*
-  * Each year, copies of this application must be submitted submitted to list all of the issues that the lobbyist is representing for its principles.
-  * A copy of this application is principle-specific, meaning that duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
+  * Each year, copies of this application must be submitted submitted to list all of the issues that the lobbyist is representing for its principals.
+  * A copy of this application is principal-specific, meaning that duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
 * *Lobbyist Expenditure Report*
 * *Notice of Withdrawal of Lobbyist Registration*
 
@@ -26,14 +26,14 @@ In addition to these forms, the ordinace requires ammendements to be filed for ?
 * Allow online lobbyist registration.
 * Usernames should be email addresses.
 * Confirmation step for lobbyists to assent that the information they submit is true.
-* Allow lobbyists to register for their Principles.
+* Allow lobbyists to register for their principals.
   * Collect the $150 fee.
   * Not-for-profit lobbyists will click on “Wave Fee.”
   * Registration is valid until December 31st in the year of registration.
   * Registration will be pending until City staff confirm ‘Not for Profit’ status.
 * Allow lobbyists to submit a withdrawal form at any time to notify the City they are no longer representing a Principal.
 * Allow Lobbyist to register each Issue.
-  * Unlike registering a Principle, this does not require a fee.
+  * Unlike registering a principal, this does not require a fee.
 * Allow Lobbyist to submit an Expenditure report online.
 * Email capabilities to send reminders, receipts and  welcome messages to active Lobbyists.
 * Reporting capabilities (Report by Lobbyist, Principal , Issue, Year of Registration, etc.)

--- a/README.md
+++ b/README.md
@@ -4,20 +4,28 @@ Lobbster is an open-source project to help lobbyists comply with reporting requi
 
 ## Background
 ### Lobbyist Responsibilities
-Ordinance No. 2017-44 creates requirements for lobbyists to submit four types of documents.
+Section 2-243 of the _Code of the City of Coral Gables_ creates requirements for non-exempt lobbyists to submit five types of documentation, four of which are submitted as forms to the City Clerk.
 
 * *Annual Registration Application*
-  * Each year, copy of this application must be submitted for each principal that the lobbyist represents.
-  * A $250 annual fee is collected with the application if 1) the lobbyist hasn't already paid the fee for the year that the application applies to and 2) the lobbyist application doesn't qualify for a number of exemptions.
+  * Each year, a separate copy of this application must be submitted for each principal that the lobbyist represents.
+  * A $250 annual fee is collected with the application if 1) the lobbyist hasn't already paid the fee for the year that the application applies to and 2) the registration application doesn't qualify for any fee exemptions.
 * *Issue Application*
-  * Each year, copies of this application must be submitted submitted to list all of the issues that the lobbyist is representing for its principals.
-  * A copy of this application is principal-specific, meaning that duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
+  * Each year, for each principal that the lobbyist represents, a copy of this application must be submitted submitted to list all of the issues that the lobbyist is representing for that principal.
+  * Because this application is principal-specific, duplicate issues represented across multiple principals will need to be reported multiple times (one time per principal).
 * *Lobbyist Expenditure Report*
+  * On October 1st of each year, lobbyists who were registered for the prior year must submit expenditure reports for the prior year, regardless of whether or not any expenses were actually incurred.
+  * These reports are specific to particular (principal, issue) pairs; a lobbyist must submit one report for each principle/issue combination that they represented.
 * *Notice of Withdrawal of Lobbyist Registration*
-
-In addition to these forms, the ordinace requires ammendements to be filed for ???.
+  * Whenever a lobbyist withdraws as lobbyist for a principal, they must file a withdrawal notice.
+* *Amendments*
+  * Amendments to these forms must be submitted whenever a change occurs to the information that has been filed. Whether the ammendments have a required format is unclear.
 
 ### City Clerk Responsibilities
+* Approve lobbyist registration and issue applications.
+* Maintain the records that are submitted.
+* Verify that fees are paid.
+* Presumably, return fees that are paid by mistake.
+* Prepare and publish reports on lobbying activity.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 ## What
 
+Lobbster is an open-source website that helps lobbyists comply with reporting requirements for the City of Coral Gables.
+
+## Requirements
+
+(This list is still in-progress.)
+
+* Allow online lobbyist registration.
+* Usernames should be email addresses.
+* Confirmation step for lobbyists to assent that the information they submit is true.
+* Allow lobbyists to register for their Principles.
+  * Collect the $150 fee.
+  * Not-for-profit lobbyists will click on “Wave Fee.”
+  * Registration is valid until December 31st in the year of registration.
+  * Registration will be pending until City staff confirm ‘Not for Profit’ status.
+* Allow lobbyists to submit a withdrawal form at any time to notify the City they are no longer representing a Principal.
+* Allow Lobbyist to register each Issue.
+  * Unlike registering a Principle, this does not require a fee.
+* Allow Lobbyist to submit an Expenditure report online.
+* Email capabilities to send reminders, receipts and  welcome messages to active Lobbyists.
+* Reporting capabilities (Report by Lobbyist, Principal , Issue, Year of Registration, etc.)
+
 #### Status
 
 Gathering Requirements.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Most of the forms require that the lobbyist sign a statement agreeing to some te
 
 ### City Clerk Responsibilities
 * Approve lobbyist registration and issue applications.
+* Verify the identities of the people who submit applications and expenditure reports.
 * Collect lobbyist fees---and presumably, return fees that are paid by mistake.
 * Maintain the records that are submitted.
 * Prepare and publish reports on lobbying activity.


### PR DESCRIPTION
This change gets the ball rolling on the README's project documentation. It adds a detailed Background section that makes it easier to bring new contributors onto the project, and also aids in the process of determining project requirements. It also includes the beginnings of a project requirements list.

The detailed background section was created from reading the City of Coral Gables' Ordinance 2017-44, as well as from reading the four lobbyist documentation forms created by the City Clerk.